### PR TITLE
Bump json-schema version

### DIFF
--- a/lib/openc/json_schema/date_converter.rb
+++ b/lib/openc/json_schema/date_converter.rb
@@ -6,14 +6,14 @@ module Openc
       def convert_dates(schema_path, record)
         validator = Utils.load_validator(schema_path, record)
         json_schema = Utils.extract_json_schema(validator)
-        _convert_dates(record, validator, json_schema, json_schema.schema)
+        _convert_dates(record, json_schema, json_schema.schema)
       end
 
-      def _convert_dates(record, validator, json_schema, schema)
+      def _convert_dates(record, json_schema, schema)
         return record if schema.nil?
 
         if (ref = schema['$ref'])
-          schema_uri = validator.absolutize_ref_uri(ref, json_schema.uri)
+          schema_uri = JSON::Util::URI.absolutize_ref(ref, json_schema.uri)
           json_schema = JSON::Validator.schema_reader.read(schema_uri)
           schema = json_schema.schema
         end
@@ -25,12 +25,12 @@ module Openc
             if properties.nil?
               [k, v]
             else
-              [k, _convert_dates(v, validator, json_schema, properties[k])]
+              [k, _convert_dates(v, json_schema, properties[k])]
             end
           end
           Hash[pairs]
         when Array
-          record.map {|e| _convert_dates(e, validator, json_schema, schema['items'])}
+          record.map {|e| _convert_dates(e, json_schema, schema['items'])}
         else
           if schema['format'] == 'date'
             begin

--- a/lib/openc/json_schema/version.rb
+++ b/lib/openc/json_schema/version.rb
@@ -1,5 +1,5 @@
 module Openc
   module JsonSchema
-    VERSION = '0.0.15'
+    VERSION = '0.0.16'
   end
 end

--- a/openc-json_schema.gemspec
+++ b/openc-json_schema.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "json", "<= 2.1"
   gem.add_dependency "json-schema", "~> 2.8"
   gem.add_dependency "json-pointer"
   gem.add_dependency "openc_json_schema_formats"

--- a/openc-json_schema.gemspec
+++ b/openc-json_schema.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json-schema", "~> 2.6.0"
+  gem.add_dependency "json-schema", "~> 2.8"
   gem.add_dependency "json-pointer"
   gem.add_dependency "openc_json_schema_formats"
   gem.add_dependency "json_validation"


### PR DESCRIPTION
This release the dependency on addressable to [>=2.4](https://github.com/ruby-json-schema/json-schema/blob/ab1253a874f05a811fdb3280ca1f77ebc9af2902/json-schema.gemspec#L26), which should allow us to upgrade morph's dependency on this repo to >0.13 and archive our [json-schema fork](https://github.com/openc/json-schema).